### PR TITLE
feat: obj binary file save & load

### DIFF
--- a/W03StaticMesh_1/Week0v2/Engine/Source/Runtime/Engine/Classes/Engine/FLoaderOBJ.h
+++ b/W03StaticMesh_1/Week0v2/Engine/Source/Runtime/Engine/Classes/Engine/FLoaderOBJ.h
@@ -6,6 +6,7 @@
 #include "EngineLoop.h"
 #include "Container/Map.h"
 #include "HAL/PlatformType.h"
+#include "Serialization/Serializer.h"
 
 struct FLoaderOBJ
 {
@@ -233,8 +234,11 @@ struct FLoaderOBJ
             {
                 LineStream >> Line;
                 OutFStaticMesh.Materials[MaterialIndex].DiffuseTextureName = Line;
-                OutFStaticMesh.Materials[MaterialIndex].DiffuseTexturePath = OutObjInfo.PathName.append(OutFStaticMesh.Materials[MaterialIndex].DiffuseTextureName.ToWideString());
+                
+                FWString TexturePath = OutObjInfo.PathName + OutFStaticMesh.Materials[MaterialIndex].DiffuseTextureName.ToWideString();
+                OutFStaticMesh.Materials[MaterialIndex].DiffuseTexturePath = TexturePath;
                 OutFStaticMesh.Materials[MaterialIndex].bHasTexture = true;
+                
                 CreateTextureFromFile(OutFStaticMesh.Materials[MaterialIndex].DiffuseTexturePath);
             }
         }
@@ -341,13 +345,24 @@ public:
         {
             return *It;
         }
-
+        
+        FWString BinaryPath = (PathFileName + ".bin").ToWideString();
+        if (std::ifstream(BinaryPath).good())
+        {
+            if (LoadStaticMeshFromBinary(BinaryPath, *NewStaticMesh))
+            {
+                ObjStaticMeshMap.Add(PathFileName, NewStaticMesh);
+                return NewStaticMesh;
+            }
+        }
+        
         // Parse OBJ
         FObjInfo NewObjInfo;
         bool Result = FLoaderOBJ::ParseOBJ(PathFileName, NewObjInfo);
 
         if (!Result)
         {
+            delete NewStaticMesh;
             return nullptr;
         }
 
@@ -358,6 +373,7 @@ public:
 
             if (!Result)
             {
+                delete NewStaticMesh;
                 return nullptr;
             }
 
@@ -368,9 +384,11 @@ public:
         Result = FLoaderOBJ::ConvertToStaticMesh(NewObjInfo, *NewStaticMesh);
         if (!Result)
         {
+            delete NewStaticMesh;
             return nullptr;
         }
 
+        SaveStaticMeshToBinary(BinaryPath, *NewStaticMesh);
         ObjStaticMeshMap.Add(PathFileName, NewStaticMesh);
         return NewStaticMesh;
     }
@@ -389,6 +407,183 @@ public:
                 }
             }
         }
+    }
+
+    static bool SaveStaticMeshToBinary(const FWString& FilePath, const OBJ::FStaticMesh& StaticMesh)
+    {
+        std::ofstream File(FilePath, std::ios::binary);
+        if (!File.is_open())
+        {
+            assert("CAN'T SAVE STATIC MESH BINARY FILE");
+            return false;
+        }
+
+        // Object Name
+        Serializer::WriteFWString(File, StaticMesh.ObjectName);
+
+        // Path Name
+        Serializer::WriteFWString(File, StaticMesh.PathName);
+
+        // Vertices
+        uint32 VertexCount = StaticMesh.Vertices.Num();
+        File.write(reinterpret_cast<const char*>(&VertexCount), sizeof(VertexCount));
+        File.write(reinterpret_cast<const char*>(StaticMesh.Vertices.GetData()), VertexCount * sizeof(FVertexSimple));
+
+        // Indices
+        uint32 IndexCount = StaticMesh.Indices.Num();
+        File.write(reinterpret_cast<const char*>(&IndexCount), sizeof(IndexCount));
+        File.write(reinterpret_cast<const char*>(StaticMesh.Indices.GetData()), IndexCount * sizeof(UINT));
+
+        // Materials
+        uint32 MaterialCount = StaticMesh.Materials.Num();
+        File.write(reinterpret_cast<const char*>(&MaterialCount), sizeof(MaterialCount));
+        for (const FObjMaterialInfo& Material : StaticMesh.Materials)
+        {
+            Serializer::WriteFString(File, Material.MTLName);
+            File.write(reinterpret_cast<const char*>(&Material.bHasTexture), sizeof(Material.bHasTexture));
+            File.write(reinterpret_cast<const char*>(&Material.bTransparent), sizeof(Material.bTransparent));
+            File.write(reinterpret_cast<const char*>(&Material.Diffuse), sizeof(Material.Diffuse));
+            File.write(reinterpret_cast<const char*>(&Material.Specular), sizeof(Material.Specular));
+            File.write(reinterpret_cast<const char*>(&Material.Ambient), sizeof(Material.Ambient));
+            File.write(reinterpret_cast<const char*>(&Material.Emissive), sizeof(Material.Emissive));
+            File.write(reinterpret_cast<const char*>(&Material.SpecularScalar), sizeof(Material.SpecularScalar));
+            File.write(reinterpret_cast<const char*>(&Material.DensityScalar), sizeof(Material.DensityScalar));
+            File.write(reinterpret_cast<const char*>(&Material.TransparencyScalar), sizeof(Material.TransparencyScalar));
+            File.write(reinterpret_cast<const char*>(&Material.IlluminanceModel), sizeof(Material.IlluminanceModel));
+
+            Serializer::WriteFString(File, Material.DiffuseTextureName);
+            Serializer::WriteFWString(File, Material.DiffuseTexturePath);
+            Serializer::WriteFString(File, Material.AmbientTextureName);
+            Serializer::WriteFWString(File, Material.AmbientTexturePath);
+            Serializer::WriteFString(File, Material.SpecularTextureName);
+            Serializer::WriteFWString(File, Material.SpecularTexturePath);
+            Serializer::WriteFString(File, Material.BumpTextureName);
+            Serializer::WriteFWString(File, Material.BumpTexturePath);
+            Serializer::WriteFString(File, Material.AlphaTextureName);
+            Serializer::WriteFWString(File, Material.AlphaTexturePath);
+        }
+
+        // Material Subsets
+        uint32 SubsetCount = StaticMesh.MaterialSubsets.Num();
+        File.write(reinterpret_cast<const char*>(&SubsetCount), sizeof(SubsetCount));
+        for (const FMaterialSubset& Subset : StaticMesh.MaterialSubsets)
+        {
+            Serializer::WriteFString(File, Subset.MaterialName);
+            File.write(reinterpret_cast<const char*>(&Subset.IndexStart), sizeof(Subset.IndexStart));
+            File.write(reinterpret_cast<const char*>(&Subset.IndexCount), sizeof(Subset.IndexCount));
+            File.write(reinterpret_cast<const char*>(&Subset.MaterialIndex), sizeof(Subset.MaterialIndex));
+        }
+
+        File.close();
+        return true;
+    }
+
+    static bool LoadStaticMeshFromBinary(const FWString& FilePath, OBJ::FStaticMesh& OutStaticMesh)
+    {
+        std::ifstream File(FilePath, std::ios::binary);
+        if (!File.is_open())
+        {
+            assert("CAN'T OPEN STATIC MESH BINARY FILE");
+            return false;
+        }
+
+        TArray<FWString> Textures;
+
+        // Object Name
+        Serializer::ReadFWString(File, OutStaticMesh.ObjectName);
+
+        // Path Name
+        Serializer::ReadFWString(File, OutStaticMesh.PathName);
+
+        // Vertices
+        uint32 VertexCount = 0;
+        File.read(reinterpret_cast<char*>(&VertexCount), sizeof(VertexCount));
+        OutStaticMesh.Vertices.SetNum(VertexCount);
+        File.read(reinterpret_cast<char*>(OutStaticMesh.Vertices.GetData()), VertexCount * sizeof(FVertexSimple));
+
+        // Indices
+        uint32 IndexCount = 0;
+        File.read(reinterpret_cast<char*>(&IndexCount), sizeof(IndexCount));
+        OutStaticMesh.Indices.SetNum(IndexCount);
+        File.read(reinterpret_cast<char*>(OutStaticMesh.Indices.GetData()), IndexCount * sizeof(UINT));
+
+        // Material
+        uint32 MaterialCount = 0;
+        File.read(reinterpret_cast<char*>(&MaterialCount), sizeof(MaterialCount));
+        OutStaticMesh.Materials.SetNum(MaterialCount);
+        for (FObjMaterialInfo& Material : OutStaticMesh.Materials)
+        {
+            Serializer::ReadFString(File, Material.MTLName);
+            File.read(reinterpret_cast<char*>(&Material.bHasTexture), sizeof(Material.bHasTexture));
+            File.read(reinterpret_cast<char*>(&Material.bTransparent), sizeof(Material.bTransparent));
+            File.read(reinterpret_cast<char*>(&Material.Diffuse), sizeof(Material.Diffuse));
+            File.read(reinterpret_cast<char*>(&Material.Specular), sizeof(Material.Specular));
+            File.read(reinterpret_cast<char*>(&Material.Ambient), sizeof(Material.Ambient));
+            File.read(reinterpret_cast<char*>(&Material.Emissive), sizeof(Material.Emissive));
+            File.read(reinterpret_cast<char*>(&Material.SpecularScalar), sizeof(Material.SpecularScalar));
+            File.read(reinterpret_cast<char*>(&Material.DensityScalar), sizeof(Material.DensityScalar));
+            File.read(reinterpret_cast<char*>(&Material.TransparencyScalar), sizeof(Material.TransparencyScalar));
+            File.read(reinterpret_cast<char*>(&Material.IlluminanceModel), sizeof(Material.IlluminanceModel));
+            Serializer::ReadFString(File, Material.DiffuseTextureName);
+            Serializer::ReadFWString(File, Material.DiffuseTexturePath);
+            Serializer::ReadFString(File, Material.AmbientTextureName);
+            Serializer::ReadFWString(File, Material.AmbientTexturePath);
+            Serializer::ReadFString(File, Material.SpecularTextureName);
+            Serializer::ReadFWString(File, Material.SpecularTexturePath);
+            Serializer::ReadFString(File, Material.BumpTextureName);
+            Serializer::ReadFWString(File, Material.BumpTexturePath);
+            Serializer::ReadFString(File, Material.AlphaTextureName);
+            Serializer::ReadFWString(File, Material.AlphaTexturePath);
+
+            if (!Material.DiffuseTexturePath.empty())
+            {
+                Textures.AddUnique(Material.DiffuseTexturePath);
+            }
+            if (!Material.AmbientTexturePath.empty())
+            {
+                Textures.AddUnique(Material.AmbientTexturePath);
+            }
+            if (!Material.SpecularTexturePath.empty())
+            {
+                Textures.AddUnique(Material.SpecularTexturePath);
+            }
+            if (!Material.BumpTexturePath.empty())
+            {
+                Textures.AddUnique(Material.BumpTexturePath);
+            }
+            if (!Material.AlphaTexturePath.empty())
+            {
+                Textures.AddUnique(Material.AlphaTexturePath);
+            }
+        }
+
+        // Material Subset
+        uint32 SubsetCount = 0;
+        File.read(reinterpret_cast<char*>(&SubsetCount), sizeof(SubsetCount));
+        OutStaticMesh.MaterialSubsets.SetNum(SubsetCount);
+        for (FMaterialSubset& Subset : OutStaticMesh.MaterialSubsets)
+        {
+            Serializer::ReadFString(File, Subset.MaterialName);
+            File.read(reinterpret_cast<char*>(&Subset.IndexStart), sizeof(Subset.IndexStart));
+            File.read(reinterpret_cast<char*>(&Subset.IndexCount), sizeof(Subset.IndexCount));
+            File.read(reinterpret_cast<char*>(&Subset.MaterialIndex), sizeof(Subset.MaterialIndex));
+        }
+
+        File.close();
+
+        // Texture Load 
+        if (Textures.Num() > 0)
+        {
+            for (const FWString& Texture : Textures)
+            {
+                if (FEngineLoop::resourceMgr.GetTexture(Texture) == nullptr)
+                {
+                    FEngineLoop::resourceMgr.LoadTextureFromFile(FEngineLoop::graphicDevice.Device, FEngineLoop::graphicDevice.DeviceContext, Texture.c_str());
+                }
+            }
+        }
+        
+        return true;
     }
 
 private:

--- a/W03StaticMesh_1/Week0v2/Engine/Source/Runtime/Serialization/Serializer.h
+++ b/W03StaticMesh_1/Week0v2/Engine/Source/Runtime/Serialization/Serializer.h
@@ -1,0 +1,48 @@
+﻿#pragma once
+#include <fstream>
+#include <vector>
+
+#include "Container/String.h"
+
+struct Serializer
+{
+    /* Write FString */
+    static void WriteFString(std::ofstream& Stream, const FString& InString)
+    {
+        uint32 Length = InString.Len();
+        Stream.write(reinterpret_cast<const char*>(&Length), sizeof(Length));
+        Stream.write(GetData(InString), Length * sizeof(char));
+    }
+
+    /* Read FString */
+    static void ReadFString(std::ifstream& Stream, FString& InString)
+    {
+        uint32 Length = 0;
+        Stream.read(reinterpret_cast<char*>(&Length), sizeof(Length));
+        char* Buffer = new char[Length + 1];
+        Stream.read(Buffer, Length);
+        Buffer[Length] = '\0';
+        InString = Buffer;
+        delete[] Buffer;
+    }
+
+    /* Write FWString */
+    static void WriteFWString(std::ofstream& Stream, const FWString& InString)
+    {
+        uint32 Length = static_cast<uint32>(InString.length());
+        Stream.write(reinterpret_cast<const char*>(&Length), sizeof(Length));
+        Stream.write(reinterpret_cast<const char*>(InString.c_str()), Length * sizeof(wchar_t));
+    }
+
+    /* Read FWString */
+    static void ReadFWString(std::ifstream& Stream, FWString& InString)
+    {
+        uint32 Length = 0;
+        Stream.read(reinterpret_cast<char*>(&Length), sizeof(Length));
+        wchar_t* Buffer = new wchar_t[Length + 1];
+        Stream.read(reinterpret_cast<char*>(Buffer), Length * sizeof(wchar_t));
+        Buffer[Length] = L'\0';
+        InString = Buffer;
+        delete[] Buffer;
+    }
+};

--- a/W03StaticMesh_1/Week0v2/Week0v2.vcxproj
+++ b/W03StaticMesh_1/Week0v2/Week0v2.vcxproj
@@ -254,6 +254,7 @@
     <ClInclude Include="Engine\Source\Editor\UnrealEd\EditorWindow.h" />
     <ClInclude Include="Engine\Source\Runtime\Launch\EngineLoop.h" />
     <ClInclude Include="Engine\Source\Runtime\Launch\ImGuiManager.h" />
+    <ClInclude Include="Engine\Source\Runtime\Serialization\Serializer.h" />
     <ClInclude Include="Engine\Source\ThirdParty\DirectXTK\Include\DDSTextureLoader.h" />
     <ClInclude Include="Font\IconDefs.h" />
     <ClInclude Include="Font\RawFonts.h" />


### PR DESCRIPTION
- .obj file 바이너리 저장 및 불러오기
- LoadObjStaticMeshAsset 함수에서 생성 실패 시 임시 생성된 FStaticMesh* delete
- FWString, FString 의 직렬화, 역직렬화를 위한 Serializer 구조체
- 기타 오류 수정 (경로 문제)